### PR TITLE
Set up Arch Linux development environment

### DIFF
--- a/os/linux/install_arch.sh
+++ b/os/linux/install_arch.sh
@@ -34,7 +34,6 @@ DEVELOPER_CLI=(
   nodejs
   npm
   zsh
-  oh-my-zsh-git           # Framework for zsh
   starship                # Modern, cross-shell prompt
   # Modern CLI tools (game changers!)
   bat                      # Better cat with syntax highlighting


### PR DESCRIPTION
- Remove oh-my-zsh-git from DEVELOPER_CLI array
- This package should not be installed via pacman as it's an AUR package
- Oh My Zsh is already properly installed via setup_oh_my_zsh() function
- Fixes 'error: target not found: oh-my-zsh-git' during installation