### PR TITLE
fix(rclone): migrate script crashes on B2 remote detection

### DIFF
--- a/services/rclone/migrate-b2-to-r2.sh
+++ b/services/rclone/migrate-b2-to-r2.sh
@@ -39,7 +39,7 @@ log_ok "rclone installed ($(rclone version | head -1))"
 B2_REMOTE=""
 for remote in $(rclone listremotes); do
   name="${remote%:}"
-  type=$(rclone config show "$name" 2>/dev/null | grep "^type" | awk '{print $3}')
+  type=$(rclone config show "$name" 2>/dev/null | grep "^type" | awk '{print $3}' || true)
   if [[ "$type" == "b2" ]]; then
     B2_REMOTE="$name"
     break
@@ -55,7 +55,7 @@ fi
 R2_REMOTE=""
 for remote in $(rclone listremotes); do
   name="${remote%:}"
-  provider=$(rclone config show "$name" 2>/dev/null | grep "^provider" | awk '{print $3}')
+  provider=$(rclone config show "$name" 2>/dev/null | grep "^provider" | awk '{print $3}' || true)
   if [[ "$provider" == "Cloudflare" ]]; then
     R2_REMOTE="$name"
     break


### PR DESCRIPTION
## What
Adds `|| true` to the `grep` calls inside the remote-detection loops in `migrate-b2-to-r2.sh`.

## Why
`grep` exits with code 1 when there's no match. With `set -euo pipefail`, this killed the script when checking the B2 remote for a `provider` field (which B2 remotes don't have). The script appeared to succeed at the pre-flight check then immediately exited with no error message.

## Test plan
- [x] Ran migration script — now proceeds past pre-flight checks correctly