### PR TITLE
feat(rclone): critical-only cloud backup, fix exclusions, add db-dumps + calibre

### DIFF
--- a/scripts/backup/backup-databases.sh
+++ b/scripts/backup/backup-databases.sh
@@ -93,6 +93,9 @@ dump_postgres "immich_postgres" "postgres" "immich"
 # Paperless-ngx (PostgreSQL)
 dump_postgres "paperless_db" "paperless" "paperless"
 
+# Linkwarden (PostgreSQL)
+dump_postgres "linkwarden_db" "linkwarden" "linkwarden"
+
 # Nextcloud (MariaDB)
 dump_mysql "nextcloud_db" "nextcloud"
 

--- a/services/rclone/rclone-backup.sh
+++ b/services/rclone/rclone-backup.sh
@@ -59,21 +59,29 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') — rclone backup started" >> "$LOG_FILE"
 log_info "Backing up $DOCKER_DIR → $BACKUP_DEST"
 [[ "$DRY_RUN" == "true" ]] && log_warn "Dry run — no data will be transferred"
 
-# Backup 1: Docker service configs
+# Backup 1: Docker service configs — critical data only
+# T7/T5 hold media; cloud holds configs + irreplaceable data
 SYNC_CMD=(rclone sync "$DOCKER_DIR" "$BACKUP_DEST")
+# Secrets — never upload
 SYNC_CMD+=(--exclude "**/.env")
-SYNC_CMD+=(--exclude "**/library/**")
-SYNC_CMD+=(--exclude "**/data/postgres/**")
-SYNC_CMD+=(--exclude "**/data/prometheus/**")
-SYNC_CMD+=(--exclude "**/jellyfin/data/**")
-SYNC_CMD+=(--exclude "**/sonarr-radarr/data/**")
-SYNC_CMD+=(--exclude "**/syncthing/data/**")
-SYNC_CMD+=(--exclude "**/actual-budget/**")
-SYNC_CMD+=(--exclude "**/audiobookshelf/data/audiobooks/**")
-SYNC_CMD+=(--exclude "**/linkwarden/**")
-SYNC_CMD+=(--exclude "**/nextcloud/data/**")
-SYNC_CMD+=(--exclude "**/karakeep/data/**")
-SYNC_CMD+=(--exclude "**/karakeep/meilisearch/**")
+# Large media — on T7/T5
+SYNC_CMD+=(--exclude "audiobookshelf/data/audiobooks/**")
+SYNC_CMD+=(--exclude "audiobookshelf/data/metadata/**")
+SYNC_CMD+=(--exclude "audiobookshelf/data/podcasts/**")
+# Postgres data dirs — back up via pg_dump instead (backup-databases.sh)
+SYNC_CMD+=(--exclude "linkwarden/data/**")
+SYNC_CMD+=(--exclude "immich/data/**")
+# Large app installs — reinstallable, not user data
+SYNC_CMD+=(--exclude "nextcloud/data/**")
+SYNC_CMD+=(--exclude "sonarr-radarr/data/**")
+SYNC_CMD+=(--exclude "grafana/data/**")
+SYNC_CMD+=(--exclude "jellyfin/data/**")
+SYNC_CMD+=(--exclude "syncthing/data/**")
+SYNC_CMD+=(--exclude "pihole/data/**")
+SYNC_CMD+=(--exclude "uptime-kuma/data/**")
+# Stopped/removed services
+SYNC_CMD+=(--exclude "karakeep/**")
+SYNC_CMD+=(--exclude "actual-budget/**")
 SYNC_CMD+=($RCLONE_FLAGS)
 [[ "$DRY_RUN" == "true" ]] && SYNC_CMD+=(--dry-run)
 
@@ -108,10 +116,45 @@ else
   log_warn "Obsidian vault not found at $OBSIDIAN_DIR — skipping"
 fi
 
-# Immich photos backup disabled — rely on T5 local backup instead
-# To re-enable, uncomment and set IMMICH_DIR / IMMICH_DEST
-# IMMICH_DIR="${IMMICH_DIR:-/Volumes/T7/immich/upload}"
-# IMMICH_DEST="${IMMICH_DEST:-${RCLONE_REMOTE}:peciulevicius-services-backup/immich-photos}"
+# Backup 3: Database dumps (weekly pg_dump output)
+DB_DUMP_DIR="$HOME/backups"
+DB_DUMP_DEST="${RCLONE_REMOTE}:peciulevicius-backups/db-dumps"
+
+if [[ -d "$DB_DUMP_DIR" ]]; then
+  log_info "Backing up $DB_DUMP_DIR → $DB_DUMP_DEST"
+  DUMP_CMD=(rclone sync "$DB_DUMP_DIR" "$DB_DUMP_DEST")
+  DUMP_CMD+=($RCLONE_FLAGS)
+  [[ "$DRY_RUN" == "true" ]] && DUMP_CMD+=(--dry-run)
+
+  if "${DUMP_CMD[@]}" 2>&1 | tee -a "$LOG_FILE"; then
+    log_ok "DB dumps backup complete"
+  else
+    log_err "DB dumps backup failed — check $LOG_FILE"
+    ((ERRORS++))
+  fi
+else
+  log_warn "DB dump dir not found at $DB_DUMP_DIR — skipping"
+fi
+
+# Backup 4: Calibre books (EPUBs on T7 — small enough for cloud)
+CALIBRE_DIR="/Volumes/T7/calibre-books"
+CALIBRE_DEST="${RCLONE_REMOTE}:peciulevicius-backups/calibre-books"
+
+if [[ -d "$CALIBRE_DIR" ]]; then
+  log_info "Backing up $CALIBRE_DIR → $CALIBRE_DEST"
+  CALIBRE_CMD=(rclone sync "$CALIBRE_DIR" "$CALIBRE_DEST")
+  CALIBRE_CMD+=($RCLONE_FLAGS)
+  [[ "$DRY_RUN" == "true" ]] && CALIBRE_CMD+=(--dry-run)
+
+  if "${CALIBRE_CMD[@]}" 2>&1 | tee -a "$LOG_FILE"; then
+    log_ok "Calibre books backup complete"
+  else
+    log_err "Calibre books backup failed — check $LOG_FILE"
+    ((ERRORS++))
+  fi
+else
+  log_warn "Calibre books not mounted at $CALIBRE_DIR — skipping"
+fi
 
 if [[ $ERRORS -gt 0 ]]; then
   log_err "Backup finished with $ERRORS error(s)"


### PR DESCRIPTION
## What
Rewrites the rclone backup exclusion list and adds two new backup targets.

## Why
The old exclusions used `**/service/data/**` which doesn't anchor correctly — rclone was uploading 10.5GB of audiobooks, 635MB of Linkwarden Postgres files, and 800MB of Nextcloud app source to R2 (13GB total, over the 10GB free tier). Cloud backup should only hold critical/irreplaceable data; T7/T5 hold everything else.

## Changes
**`rclone-backup.sh`**
- Fixed all exclusions to use anchored paths (`audiobookshelf/data/audiobooks/**` not `**/audiobookshelf/data/audiobooks/**`)
- Excluded: audiobookshelf media, linkwarden Postgres data, nextcloud app, sonarr-radarr, grafana, jellyfin metadata, syncthing state, pihole, uptime-kuma history, karakeep, actual-budget
- Added Backup 3: `~/backups/` (weekly db dumps) → `r2:peciulevicius-backups/db-dumps`
- Added Backup 4: `/Volumes/T7/calibre-books/` → `r2:peciulevicius-backups/calibre-books` (skips if T7 not mounted)

**`backup-databases.sh`**
- Added Linkwarden PostgreSQL dump

## Expected R2 size after next backup
~500MB (down from 13GB): vaultwarden, paperless docs, calibre metadata, mealie, freshrss, obsidian vault, db dumps, calibre books (~346MB)

## Test plan
- [x] Dry run passes all 4 targets
- [ ] Run live backup, verify R2 drops to ~500MB
- [ ] Verify calibre books appear in `r2:peciulevicius-backups/calibre-books`
- [ ] Verify db-dumps appear in `r2:peciulevicius-backups/db-dumps`