### PR TITLE
fix(rclone): add --delete-excluded to prevent stale files in R2

### DIFF
--- a/services/rclone/rclone-backup.sh
+++ b/services/rclone/rclone-backup.sh
@@ -32,7 +32,7 @@ fi
 RCLONE_REMOTE="${RCLONE_REMOTE:-b2-backup}"
 DOCKER_DIR="${DOCKER_DIR:-$HOME/services}"
 BACKUP_DEST="${BACKUP_DEST:-${RCLONE_REMOTE}:peciulevicius-services-backup/services}"
-RCLONE_FLAGS="${RCLONE_FLAGS:---transfers=4 --checkers=8 --fast-list --stats=60s}"
+RCLONE_FLAGS="${RCLONE_FLAGS:---transfers=4 --checkers=8 --fast-list --stats=60s --delete-excluded}"
 
 ERRORS=0
 


### PR DESCRIPTION
## What
Adds `--delete-excluded` to the default `RCLONE_FLAGS`.

## Why
Without this flag, files that become excluded (e.g. a service data dir we stop backing up) remain in R2 indefinitely. This caused R2 to grow to 14GB because old excluded paths (audiobookshelf audiobooks, linkwarden Postgres, etc.) were never cleaned up. Those had to be manually purged.

With `--delete-excluded`, rclone sync will remove files from R2 that match the exclude rules on the next run.

## Test plan
- [x] Dry run passes
- [ ] Confirm R2 stays at ~1.3GB on next nightly run