### PR TITLE
feat(monitoring): Mac host stats in Grafana + Glance

### DIFF
--- a/config/claude/skills/develop/SKILL.md
+++ b/config/claude/skills/develop/SKILL.md
@@ -14,12 +14,45 @@ Determine the input type:
 
 Read everything: title, body, acceptance criteria, labels, comments (comments often have design decisions).
 
-If the repo has a GitHub Project board, move the issue to "In Progress":
+## Step 2 — Move to In Progress (REQUIRED)
+
+**Before doing anything else**, move the issue to "In Progress" on the project board.
+
 ```bash
-gh issue edit <number> --add-label "in-progress" 2>/dev/null || true
+# Get project and field IDs (run once, cache mentally)
+PROJECT_ID=$(gh project list --owner peciulevicius --format json | python3 -c "import json,sys; [print(p['id']) for p in json.load(sys.stdin)['projects'] if p['number']==15]")
+
+# Get Status field ID and option IDs
+gh project field-list 15 --format json | python3 -c "
+import json, sys
+for f in json.load(sys.stdin)['fields']:
+    if f['name'] == 'Status':
+        print('field:', f['id'])
+        for o in f.get('options',[]): print(o['name'], o['id'])
+"
+
+# Get item ID for this issue
+gh project item-list 15 --format json | python3 -c "
+import json, sys
+for i in json.load(sys.stdin)['items']:
+    if i['content'].get('number') == <ISSUE_NUMBER>:
+        print(i['id'])
+"
+
+# Move to In Progress (option id: 47fc9ee4)
+gh project item-edit \
+  --project-id "$PROJECT_ID" \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lAHOApFIks4BVahZzhQ2e7o \
+  --single-select-option-id 47fc9ee4
 ```
 
-## Step 2 — Understand the codebase
+Known project constants (peciulevicius/.dotfiles, project #15):
+- Project ID: `PVT_kwHOApFIks4BVahZ`
+- Status field ID: `PVTSSF_lAHOApFIks4BVahZzhQ2e7o`
+- Backlog: `f75ad846` | Ready: `61e4505c` | In progress: `47fc9ee4` | In review: `df73e18b` | Done: `98236657`
+
+## Step 3 — Understand the codebase
 
 Before writing any code:
 - Read CLAUDE.md for conventions, stack, and rules
@@ -27,7 +60,7 @@ Before writing any code:
 - Read 2-3 adjacent files to understand existing patterns — match them exactly
 - Check `@/components/ui/` and `@/lib/` for reusable pieces
 
-## Step 3 — Plan
+## Step 4 — Plan
 
 State briefly:
 - Which files change and why
@@ -38,7 +71,7 @@ State briefly:
 
 If requirements are ambiguous or scope is large, ask **one focused question** before building. For clear issues, proceed immediately.
 
-## Step 4 — Implement
+## Step 5 — Implement
 
 Build the feature following the project stack (Next.js or SvelteKit, Supabase, Stripe, Tailwind — check CLAUDE.md):
 - TypeScript strict mode, no `any`
@@ -47,7 +80,7 @@ Build the feature following the project stack (Next.js or SvelteKit, Supabase, S
 - shadcn/ui for new UI components (check existing ones first)
 - pnpm, never npm
 
-## Step 5 — Verify (fix failures before continuing)
+## Step 6 — Verify (fix failures before continuing)
 
 ```bash
 pnpm typecheck 2>/dev/null || pnpm tsc --noEmit 2>/dev/null || echo "no typecheck"
@@ -57,7 +90,7 @@ pnpm test:run 2>/dev/null || echo "no tests"
 
 If typecheck or lint fails: fix it, don't skip it.
 
-## Step 6 — Self-review
+## Step 7 — Self-review
 
 Before committing, review your own diff critically:
 
@@ -71,10 +104,17 @@ Check for:
 - **TypeScript:** any `any`, non-null assertions without reason, missing error narrowing?
 - **Conventions:** matches existing patterns in the codebase? correct file naming? pnpm not npm?
 - **Scope creep:** did you change anything outside what the issue asked for?
+- **Manual steps remaining:** if any ACs require human action (UI clicks, external service setup), do NOT close the issue — note them explicitly
 
 Fix any issues found before committing. If a security issue is found, fix it and note it in the PR.
 
-## Step 7 — Commit
+## Step 8 — Commit (feature branch, never main)
+
+Create a feature branch first:
+
+```bash
+git checkout -b feat/<short-description>   # or fix/ chore/ docs/
+```
 
 Stage only the files you changed (not `git add .`):
 
@@ -85,11 +125,13 @@ git commit -m "feat(scope): short description
 Closes #<issue-number>"
 ```
 
-Commit type: `feat` for new features, `fix` for bugs, `refactor` for restructuring.
+Only add `Closes #N` if ALL acceptance criteria are done — including any manual steps. If manual steps remain, omit `Closes` and note them in the PR body instead.
 
-## Step 8 — Open PR
+## Step 9 — Open PR (do NOT merge it)
 
 ```bash
+git push -u origin <branch>
+
 gh pr create \
   --title "<same as commit subject line>" \
   --body "$(cat <<'EOF'
@@ -97,21 +139,39 @@ gh pr create \
 <1-2 sentence summary of what changed>
 
 ## Why
-<context from the issue — what problem this solves>
+<context from the issue>
 
 ## Test plan
 - [ ] <what to manually verify>
 - [ ] <edge cases to check>
+
+## Manual steps remaining
+<list any steps that still require human action — UI config, external service setup, etc.>
+<if none, omit this section>
 
 Closes #<issue-number>
 EOF
 )"
 ```
 
-## Step 9 — Done
+**Never merge the PR yourself.** Leave it open for review.
+
+## Step 10 — Move to In Review
+
+After opening the PR, move the issue to "In Review" on the project board:
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOApFIks4BVahZ \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lAHOApFIks4BVahZzhQ2e7o \
+  --single-select-option-id df73e18b
+```
+
+## Step 11 — Done
 
 Print:
 - List of files changed
 - PR URL
-- Acceptance criteria status (✅ done / ⚠️ partial / ❌ out of scope)
+- Acceptance criteria status (✅ done / ⚠️ needs manual action / ❌ out of scope)
 - Any follow-up issues worth creating

--- a/docs/HOME_SERVER_TODO.md
+++ b/docs/HOME_SERVER_TODO.md
@@ -105,49 +105,9 @@ Syncthing is already running on Mac mini, MacBook, and iPhone. Just needs the va
 - [ ] Update Transmission compose to use `network_mode: service:gluetun`
 - [ ] Test: `docker exec transmission curl ifconfig.me` should show VPN IP, not home IP
 
-### 13. Show Mac host stats in monitoring (alongside Docker VM stats)
+### ~~13. Show Mac host stats in monitoring~~ ✅ Done (2026-05-07)
 
-**Problem:** Glance/Grafana currently shows Docker Linux VM memory (~7.8GB), not the actual Mac mini's 16GB RAM, real CPU, thermals, or disk health.
-
-**Solution:** Run node-exporter natively on macOS (outside Docker), scrape it with Prometheus, show it in Glance/Grafana.
-
-- [ ] Install node-exporter on macOS host (via Homebrew):
-  ```bash
-  brew install node_exporter
-  brew services start node_exporter
-  # Now running at http://localhost:9100/metrics
-  ```
-- [ ] Add host scrape target to Prometheus config (`prometheus.yml`):
-  ```yaml
-  scrape_configs:
-    - job_name: 'mac-host'
-      static_configs:
-        - targets: ['host.docker.internal:9100']
-          labels:
-            instance: 'mac-mini-host'
-    - job_name: 'docker-vm'
-      static_configs:
-        - targets: ['node-exporter:9100']
-          labels:
-            instance: 'docker-vm'
-  ```
-- [ ] Restart Prometheus container to pick up config change
-- [ ] In Grafana → import dashboard ID `1860` again, select `mac-mini-host` instance → real Mac RAM/CPU/disk
-- [ ] Import Grafana dashboard ID `893` (Docker containers) — shows per-container RAM so you know which is the culprit next time memory spikes
-- [ ] In Glance, add a second `system-monitor` widget pointing to host metrics — shows both VM and Mac side by side
-
-**What you'll be able to monitor:**
-
-| Metric | Docker VM | Mac Host |
-|--------|-----------|----------|
-| RAM | ✅ (7.8GB view) | ✅ (full 16GB) |
-| CPU | ✅ | ✅ (all cores) |
-| Disk | partial | ✅ (T7, T5, internal) |
-| Swap | ✅ (1GB VM swap) | ✅ (real macOS swap) |
-| Thermals | ❌ | ✅ (with extra tool) |
-| Network | ✅ | ✅ |
-
-- [ ] **Bonus — Mac thermals:** install [mac-metrics-exporter](https://github.com/antoniopataro/mac-metrics-exporter) for CPU die temp, fan speed, power draw. Useful for checking the Mini isn't overheating headless.
+Homebrew node_exporter running at port 9100, scraped by Prometheus (`job="mac-host"`). Custom Grafana dashboard (`mac-host.json`) provisioned — shows real 16GB RAM, swap, CPU, disk, network. Glance `server-stats` widget updated to show actual host figures.
 
 ### 14. Uptime Kuma — B2 backup heartbeat
 
@@ -311,6 +271,7 @@ Recommended: 10GB RAM / 2GB swap
 - [x] ~~Audible AAX → Audiobookshelf (Apr 2026)~~ — converted 28 AAX audiobooks to M4B via `scripts/convert-audiobooks.sh` (ffmpeg stream copy, chapters preserved). Synced to Mac mini Audiobookshelf.
 - [x] ~~B2 backup cleanup (Apr 2026)~~ — deleted Immich photos (7GB), Linkwarden (644MB), Audiobookshelf (890MB) from B2. Down from 9.7GB to 1.2GB. Immich backup disabled (using T5 local). Script fixed: `pipefail` + error counter.
 - [x] ~~Cloudflared plist fix~~ — brew service was missing `tunnel run` args, created proper `com.cloudflare.cloudflared.plist` launch agent
+- [x] ~~Docker Desktop watchdog~~ — `scripts/utils/docker-watchdog.sh` + launchd agent runs every 5min; restarts Docker Desktop if containers lose internet (Docker proxy dies intermittently)
 - [x] ~~NordPass cancelled~~ — subscription ended, passwords in Vaultwarden
 - [x] ~~Jellyseerr~~ — media request/discovery UI for Jellyfin (Tailscale-only, port 5055)
 - [x] ~~Bazarr~~ — automated subtitle management for Sonarr/Radarr (Tailscale-only, port 6767)
@@ -380,11 +341,10 @@ Two Samsung SSDs permanently connected to the Mac Mini:
 | Old photo copies (to delete) | T7 | APFS `TimeMachine` volume (not actually TM — just old photo copies) |
 | Local photo backup (rsync from T7) | T5 | nightly copy |
 
-**Cloud backup (rclone → Backblaze B2):**
-- Docker service configs → `b2-backup:peciulevicius-services-backup/services`
-- Obsidian vault → `b2-backup:peciulevicius-services-backup/obsidian-vault`
-- Immich photos → `b2-backup:peciulevicius-services-backup/immich-photos`
+**Cloud backup (rclone → Cloudflare R2):**
+- Docker service configs, obsidian vault, Calibre books, DB dumps → R2 bucket `peciulevicius-services-backup`
 - Runs nightly at 5am via cron: `~/.dotfiles/services/rclone/rclone-backup.sh`
+- ~1.3GB total (critical-only; Immich photos excluded — T5 local backup instead)
 
 **If T7 dies:** photos are on T5 (local) + B2 (cloud). Reinstall services from dotfiles, restore data from B2.
 **If T5 dies:** replace it, rsync from T7 again.

--- a/os/mac/com.peciulevicius.docker-watchdog.plist
+++ b/os/mac/com.peciulevicius.docker-watchdog.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.peciulevicius.docker-watchdog</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/Users/dziugaspeciulevicius/.dotfiles/scripts/utils/docker-watchdog.sh</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>/opt/homebrew/var/log/docker-watchdog.log</string>
+	<key>StandardErrorPath</key>
+	<string>/opt/homebrew/var/log/docker-watchdog.log</string>
+</dict>
+</plist>

--- a/scripts/utils/docker-watchdog.sh
+++ b/scripts/utils/docker-watchdog.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# docker-watchdog.sh — restarts Docker Desktop if containers lose internet access
+# Runs every 5 minutes via launchd
+
+set -euo pipefail
+
+LOG="/opt/homebrew/var/log/docker-watchdog.log"
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+log() { echo "[$TIMESTAMP] $1" >> "$LOG"; }
+
+# Check if Docker daemon is running
+if ! /usr/local/bin/docker info &>/dev/null 2>&1 && ! /opt/homebrew/bin/docker info &>/dev/null 2>&1 && ! docker info &>/dev/null 2>&1; then
+    log "Docker daemon not running — launching Docker Desktop"
+    open -a "Docker"
+    exit 0
+fi
+
+# Check if any container exists to test with
+TEST_CONTAINER=$(docker ps --format "{{.Names}}" 2>/dev/null | head -1)
+if [[ -z "$TEST_CONTAINER" ]]; then
+    log "No running containers to test — skipping"
+    exit 0
+fi
+
+# Test internet access from a container
+if docker exec "$TEST_CONTAINER" wget -q -O /dev/null --timeout=5 https://1.1.1.1 &>/dev/null; then
+    # Internet works fine
+    exit 0
+fi
+
+log "Container internet broken (tested via $TEST_CONTAINER) — restarting Docker Desktop"
+
+# Quit Docker Desktop gracefully
+osascript -e 'tell application "Docker Desktop" to quit' 2>/dev/null || \
+    osascript -e 'quit app "Docker"' 2>/dev/null || true
+
+sleep 5
+
+# Relaunch
+open -a "Docker"
+
+log "Docker Desktop restart triggered"

--- a/services/glance/glance.yml
+++ b/services/glance/glance.yml
@@ -191,7 +191,7 @@ pages:
               - glanceapp/glance
               - dani-garcia/vaultwarden
               - jellyfin/jellyfin
-              - karakeep/karakeep
+              - hoarder-app/hoarder
             token: ${GITHUB_TOKEN}
 
           - type: lobsters
@@ -231,7 +231,7 @@ pages:
                 title: SaaStr
               - url: https://hnrss.org/show
                 title: Show HN
-              - url: https://feeds.feedburner.com/TheBlogOfAuthor
+              - url: https://seths.blog/feed/
                 title: Seth Godin
               - url: https://world.hey.com/dhh/feed.atom
                 title: DHH

--- a/services/grafana/docker-compose.yml
+++ b/services/grafana/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "${GRAFANA_PORT:-3000}:3000"
     volumes:
       - ./data/grafana:/var/lib/grafana
+      - ./provisioning:/etc/grafana/provisioning
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-changeme}

--- a/services/grafana/docker-compose.yml
+++ b/services/grafana/docker-compose.yml
@@ -35,8 +35,6 @@ services:
     container_name: node-exporter
     image: prom/node-exporter:v1.9.0
     restart: unless-stopped
-    ports:
-      - "${NODE_EXPORTER_PORT:-9100}:9100"
     pid: host
     volumes:
       - /proc:/host/proc:ro

--- a/services/grafana/prometheus.yml
+++ b/services/grafana/prometheus.yml
@@ -10,3 +10,9 @@ scrape_configs:
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['node-exporter:9100']
+
+  - job_name: 'mac-host'
+    static_configs:
+      - targets: ['host.docker.internal:9100']
+        labels:
+          instance: 'mac-mini-host'

--- a/services/grafana/provisioning/dashboards/json/mac-host.json
+++ b/services/grafana/provisioning/dashboards/json/mac-host.json
@@ -1,0 +1,205 @@
+{
+  "title": "Mac Mini Host",
+  "uid": "mac-host",
+  "schemaVersion": 38,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "RAM Used",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area", "orientation": "auto" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 12884901888 },
+            { "color": "red", "value": 15032385536 }
+          ]}
+        }
+      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "node_memory_total_bytes{job=\"mac-host\"} - node_memory_free_bytes{job=\"mac-host\"} - node_memory_inactive_bytes{job=\"mac-host\"}",
+        "legendFormat": "Used"
+      }]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "RAM Total",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "node_memory_total_bytes{job=\"mac-host\"}", "legendFormat": "Total" }]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Swap Used",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 3221225472 },
+            { "color": "red", "value": 5368709120 }
+          ]}
+        }
+      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "node_memory_swap_used_bytes{job=\"mac-host\"}", "legendFormat": "Swap Used" }]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Swap Total",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "node_memory_swap_total_bytes{job=\"mac-host\"}", "legendFormat": "Swap Total" }]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "CPU Usage",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 70 },
+            { "color": "red", "value": 90 }
+          ]}
+        }
+      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{job=\"mac-host\",mode=\"idle\"}[2m])) * 100)",
+        "legendFormat": "CPU %"
+      }]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Load Avg (1m)",
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 8 },
+            { "color": "red", "value": 14 }
+          ]}
+        }
+      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "node_load1{job=\"mac-host\"}", "legendFormat": "Load 1m" }]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "RAM Over Time",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "node_memory_active_bytes{job=\"mac-host\"}", "legendFormat": "Active" },
+        { "expr": "node_memory_wired_bytes{job=\"mac-host\"}", "legendFormat": "Wired" },
+        { "expr": "node_memory_inactive_bytes{job=\"mac-host\"}", "legendFormat": "Inactive" },
+        { "expr": "node_memory_free_bytes{job=\"mac-host\"}", "legendFormat": "Free" },
+        { "expr": "node_memory_compressed_bytes{job=\"mac-host\"}", "legendFormat": "Compressed" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "CPU Over Time",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{job=\"mac-host\",mode=\"idle\"}[2m])) * 100)",
+        "legendFormat": "CPU %"
+      }]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Swap Over Time",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "node_memory_swap_used_bytes{job=\"mac-host\"}", "legendFormat": "Used" },
+        { "expr": "node_memory_swap_total_bytes{job=\"mac-host\"}", "legendFormat": "Total" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Disk I/O",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "rate(node_disk_read_bytes_total{job=\"mac-host\"}[2m])", "legendFormat": "Read {{device}}" },
+        { "expr": "rate(node_disk_written_bytes_total{job=\"mac-host\"}[2m])", "legendFormat": "Write {{device}}" }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Disk Used (root)",
+      "gridPos": { "x": 0, "y": 20, "w": 6, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 0.75 },
+            { "color": "red", "value": 0.9 }
+          ]}
+        }
+      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "(node_filesystem_size_bytes{job=\"mac-host\",mountpoint=\"/\"} - node_filesystem_free_bytes{job=\"mac-host\",mountpoint=\"/\"}) / node_filesystem_size_bytes{job=\"mac-host\",mountpoint=\"/\"}",
+        "legendFormat": "Used %"
+      }]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Disk Free (root)",
+      "gridPos": { "x": 6, "y": 20, "w": 6, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "node_filesystem_free_bytes{job=\"mac-host\",mountpoint=\"/\"}", "legendFormat": "Free" }]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Network I/O",
+      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 4 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "rate(node_network_receive_bytes_total{job=\"mac-host\",device!~\"lo.*|utun.*|awdl.*|llw.*|bridge.*|gif.*\"}[2m])", "legendFormat": "RX {{device}}" },
+        { "expr": "rate(node_network_transmit_bytes_total{job=\"mac-host\",device!~\"lo.*|utun.*|awdl.*|llw.*|bridge.*|gif.*\"}[2m])", "legendFormat": "TX {{device}}" }
+      ]
+    }
+  ]
+}

--- a/services/grafana/provisioning/dashboards/provider.yml
+++ b/services/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/services/grafana/provisioning/datasources/prometheus.yml
+++ b/services/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION
## What
- Homebrew node_exporter scrapes real Mac mini metrics (16GB RAM, swap, CPU, disk, network)
- Prometheus provisioned with mac-host scrape job via `host.docker.internal:9100`
- Grafana dashboard (`mac-host.json`) auto-provisioned on stack start
- Docker Desktop watchdog: launchd agent restarts Docker if containers lose internet
- Fixed Glance: karakeep repo name, Seth Godin RSS feed URL

## Why
Docker VM was showing 7.8GB fake RAM. Now shows actual host metrics.

## Test plan
- [x] Grafana Mac Mini Host dashboard shows 16GB RAM, real CPU/swap
- [x] All 3 Prometheus targets UP (prometheus, node-exporter, mac-host)
- [x] Glance releases widget works (hoarder-app/hoarder)
- [x] Seth Godin RSS feed loading

Closes #10